### PR TITLE
Fix ATS Brake

### DIFF
--- a/hk.hpp
+++ b/hk.hpp
@@ -309,6 +309,8 @@ public:
 			else{m_result_lim = ATSEB_NONE;}
 			break;
 		case LIMIT_F:
+		m_result_lim = ATSEB_NONE;
+		//2015.5.9 szhal 新A点照査のATSブレーキが解除されない対策
 		default:
 			break;
 		}


### PR DESCRIPTION
新A点のATSブレーキ動作中に新A点解除BEACON(17,1,0)を踏んだ場合、ATSブレーキが緩解されず
残ってしまう対策です
(宝塚線、服部天神での駅スキップ通過処理の対策)

なお、ATSブレーキ作動で切れた断流機がマスコン再操作しないと復帰しない
仕様となってますが、これはJ9からの変更依頼ですか？